### PR TITLE
Advising (compat-function completion-metadata-get). Fix #11

### DIFF
--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -141,8 +141,8 @@ PROP is the property which is looked up."
   :global t
   (if nerd-icons-completion-mode
       (progn
-	(advice-add #'completion-metadata-get :around #'nerd-icons-completion-completion-metadata-get)
-	(advice-add (compat-function completion-metadata-get) :around #'nerd-icons-completion-completion-metadata-get))
+        (advice-add #'completion-metadata-get :around #'nerd-icons-completion-completion-metadata-get)
+        (advice-add (compat-function completion-metadata-get) :around #'nerd-icons-completion-completion-metadata-get))
     (progn
       (advice-remove #'completion-metadata-get #'nerd-icons-completion-completion-metadata-get)
       (advice-remove (compat-function completion-metadata-get) #'nerd-icons-completion-completion-metadata-get))))

--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -5,7 +5,7 @@
 ;; Author: Hongyu Ding <rainstormstudio@yahoo.com>
 ;; Keywords: lisp
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "25.1") (nerd-icons "0.0.1"))
+;; Package-Requires: ((emacs "25.1") (nerd-icons "0.0.1") (compat "30"))
 ;; URL: https://github.com/rainstormstudio/nerd-icons-completion
 ;; Keywords: convenient, files, icons
 
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'nerd-icons)
+(require 'compat)
 
 (defgroup nerd-icons-completion nil
   "Add icons to completion candidates."

--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -139,8 +139,12 @@ PROP is the property which is looked up."
   "Add icons to completion candidates."
   :global t
   (if nerd-icons-completion-mode
-      (advice-add #'completion-metadata-get :around #'nerd-icons-completion-completion-metadata-get)
-    (advice-remove #'completion-metadata-get #'nerd-icons-completion-completion-metadata-get)))
+      (progn
+	(advice-add #'completion-metadata-get :around #'nerd-icons-completion-completion-metadata-get)
+	(advice-add (compat-function completion-metadata-get) :around #'nerd-icons-completion-completion-metadata-get))
+    (progn
+      (advice-remove #'completion-metadata-get #'nerd-icons-completion-completion-metadata-get)
+      (advice-remove (compat-function completion-metadata-get) #'nerd-icons-completion-completion-metadata-get))))
 
 (provide 'nerd-icons-completion)
 ;;; nerd-icons-completion.el ends here


### PR DESCRIPTION
Following https://github.com/minad/marginalia/commit/f2ac221aba25a8eeb5d0d607b8cca2d01998689f, compatibility with Marginalia was broken. Advising (compat-function completion-metadata-get) restores it. Fixes #11.