### PR TITLE
Use compat 30 to get the real completion-metadata-get

### DIFF
--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -5,7 +5,7 @@
 ;; Author: Hongyu Ding <rainstormstudio@yahoo.com>
 ;; Keywords: lisp
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "25.1") (nerd-icons "0.0.1"))
+;; Package-Requires: ((emacs "25.1") (nerd-icons "0.0.1") (compat "30"))
 ;; URL: https://github.com/rainstormstudio/nerd-icons-completion
 ;; Keywords: convenient, files, icons
 
@@ -30,6 +30,7 @@
 
 ;;; Code:
 
+(require 'compat)
 (require 'nerd-icons)
 
 (defgroup nerd-icons-completion nil
@@ -139,8 +140,8 @@ PROP is the property which is looked up."
   "Add icons to completion candidates."
   :global t
   (if nerd-icons-completion-mode
-      (advice-add #'completion-metadata-get :around #'nerd-icons-completion-completion-metadata-get)
-    (advice-remove #'completion-metadata-get #'nerd-icons-completion-completion-metadata-get)))
+      (advice-add (compat-function completion-metadata-get) :around #'nerd-icons-completion-completion-metadata-get)
+    (advice-remove (compat-function completion-metadata-get) #'nerd-icons-completion-completion-metadata-get)))
 
 (provide 'nerd-icons-completion)
 ;;; nerd-icons-completion.el ends here


### PR DESCRIPTION
Since https://github.com/minad/vertico/commit/f9580665ce1b896f1ad6d9c6b7ceb47c748eb073, vertico uses `(compat-call completion-metadata-get)` to call `completion-metadata-get`. To advice the correct function, we should use `(compat-function)` to get the real name of the function.

Without this patch, the newest vertico is incompatible with nerd-icons-completion.