### PR TITLE
Pacify compiler warning

### DIFF
--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -175,7 +175,7 @@ This should map the kind to `eglot--kind-names' and
 (autoload 'bookmark-get-filename "bookmark")
 (cl-defmethod nerd-icons-completion-get-icon (cand (_cat (eql bookmark)))
   "Return the icon for the candidate CAND of completion category bookmark."
-  (when-let ((bm (assoc cand (bound-and-true-p bookmark-alist))))
+  (when-let* ((bm (assoc cand (bound-and-true-p bookmark-alist))))
     (if-let* ((fname (bookmark-get-filename cand)))
         (nerd-icons-completion-get-icon fname 'file)
       (concat (nerd-icons-octicon "nf-oct-bookmark"


### PR DESCRIPTION
* nerd-icons-completion.el (nerd-icons-completion-get-icon): Use `when-let*' instead of `when-let' in order to silence the compiler for using an obsolete macro (as of 31.1).