### PR TITLE
Use nerd-icons-icon-for-buffer for buffer candidates

### DIFF
--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -160,16 +160,11 @@ This should map the kind to `eglot--kind-names' and
 
 (cl-defmethod nerd-icons-completion-get-icon (cand (_cat (eql buffer)))
   "Return the icon for the candidate CAND of completion category buffer."
-  (let* ((mode (buffer-local-value 'major-mode (get-buffer cand)))
-         (icon (nerd-icons-icon-for-mode mode :height nerd-icons-completion-icon-size))
-         (parent-icon (nerd-icons-icon-for-mode
-                       (get mode 'derived-mode-parent)
-                       :height nerd-icons-completion-icon-size)))
+  (let ((icon (with-current-buffer cand
+                (nerd-icons-icon-for-buffer :height nerd-icons-completion-icon-size))))
     (concat
      (if (symbolp icon)
-         (if (symbolp parent-icon)
-             (nerd-icons-faicon "nf-fa-sticky_note_o" :height nerd-icons-completion-icon-size)
-           parent-icon)
+         (nerd-icons-faicon "nf-fa-sticky_note_o" :height nerd-icons-completion-icon-size)
        icon)
      " ")))
 


### PR DESCRIPTION
1. `nerd-icons-icon-for-mode` (called by `nerd-icons-icon-for-buffer`) already checks for icons for the parent mode.

2. `nerd-icons-icon-for-buffer` prefers the buffer's file icon, which should work better for modes that support multiple file types (e.g., web-mode).

I've also taken the chance to simplify the logic a bit.