### PR TITLE
fix: handle renamed or killed buffers in buffer icon lookup

### DIFF
--- a/nerd-icons-completion.el
+++ b/nerd-icons-completion.el
@@ -160,13 +160,15 @@ This should map the kind to `eglot--kind-names' and
 
 (cl-defmethod nerd-icons-completion-get-icon (cand (_cat (eql buffer)))
   "Return the icon for the candidate CAND of completion category buffer."
-  (let ((icon (with-current-buffer cand
-                (nerd-icons-icon-for-buffer :height nerd-icons-completion-icon-size))))
-    (concat
-     (if (symbolp icon)
-         (nerd-icons-faicon "nf-fa-sticky_note_o" :height nerd-icons-completion-icon-size)
-       icon)
-     " ")))
+  (if-let* ((buf (get-buffer cand)))
+      (let ((icon (with-current-buffer buf
+                    (nerd-icons-icon-for-buffer :height nerd-icons-completion-icon-size))))
+        (concat
+         (if (symbolp icon)
+             (nerd-icons-faicon "nf-fa-sticky_note_o" :height nerd-icons-completion-icon-size)
+           icon)
+         " "))
+    ""))
 
 (autoload 'bookmark-get-filename "bookmark")
 (cl-defmethod nerd-icons-completion-get-icon (cand (_cat (eql bookmark)))


### PR DESCRIPTION
with-current-buffer signals an error when the candidate buffer no longer exists (e.g. renamed asynchronously by a process filter while the completion UI is rendering).  Guard with get-buffer and return an empty string when the buffer is gone.

This happens with https://codeberg.org/ezemtsov/ewm where the wayland windows can change titles on a separate thread.